### PR TITLE
Moved instructions from 'deploy' to 'build' action hook

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export COMPOSER_HOME="$OPENSHIFT_DATA_DIR/.composer"
+
+if [ ! -f "$OPENSHIFT_DATA_DIR/composer.phar" ]; then
+    curl -s https://getcomposer.org/installer | /usr/bin/php -- --install-dir=$OPENSHIFT_DATA_DIR
+else
+    /usr/bin/php $OPENSHIFT_DATA_DIR/composer.phar self-update
+fi
+
+unset GIT_DIR
+cd $OPENSHIFT_REPO_DIR/php
+/usr/bin/php $OPENSHIFT_DATA_DIR/composer.phar install
+

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -1,13 +1,1 @@
 #!/bin/sh
-
-export COMPOSER_HOME="$OPENSHIFT_DATA_DIR/.composer"
-
-if [ ! -f "$OPENSHIFT_DATA_DIR/composer.phar" ]; then
-    curl -s https://getcomposer.org/installer | /usr/bin/php -- --install-dir=$OPENSHIFT_DATA_DIR
-else
-    /usr/bin/php $OPENSHIFT_DATA_DIR/composer.phar self-update
-fi
-
-unset GIT_DIR
-cd $OPENSHIFT_REPO_DIR/php
-/usr/bin/php $OPENSHIFT_DATA_DIR/composer.phar install


### PR DESCRIPTION
As stated in https://access.redhat.com/documentation/en-US/OpenShift_Online/2.0/html/User_Guide/chap-Build_and_Deployment.html#About_Deployment

![doc](https://cloud.githubusercontent.com/assets/1259313/10183216/8780c5d6-6703-11e5-9b16-ca9f70de4a1b.png)

In this way, the right step to install dependencies should be during the **build**, instead of the **deploy** itself. So all dependencies should be installed into this step.
